### PR TITLE
Refactor timing and clean up merge artifacts

### DIFF
--- a/bullet.py
+++ b/bullet.py
@@ -1,18 +1,20 @@
 import pygame
+from typing import Tuple
 from settings import WIDTH, BULLET_SPEED
 
 
 class Bullet(pygame.sprite.Sprite):
     """Projectile fired by the player."""
 
-    def __init__(self, pos, direction):
+    def __init__(self, pos: Tuple[int, int], direction: int):
         super().__init__()
         self.image = pygame.Surface((10, 4))
         self.image.fill((255, 255, 0))
         self.rect = self.image.get_rect(center=pos)
         self.speed = BULLET_SPEED * direction
 
-    def update(self):
-        self.rect.x += self.speed
+    def update(self, dt: float) -> None:
+        """Move the bullet and remove it when off-screen."""
+        self.rect.x += int(self.speed * dt)
         if self.rect.right < 0 or self.rect.left > WIDTH:
             self.kill()

--- a/enemy.py
+++ b/enemy.py
@@ -1,132 +1,83 @@
+"""Enemy sprite classes with simple time-based movement."""
+
+from __future__ import annotations
+
 import math
+from typing import Sequence, TYPE_CHECKING
+
 import pygame
 
-from settings import ENEMY_SPEED, GROUND_LEVEL, WIDTH
 from animation import Animation, load_sprite_sheet
+from settings import ENEMY_SPEED, GROUND_LEVEL, WIDTH
+
+if TYPE_CHECKING:
+    from item import Item
 
 
 class Enemy(pygame.sprite.Sprite):
     """Base enemy class handling movement and animation."""
 
-    def __init__(self, x_pos, frames, speed, frame_time):
+    def __init__(
+        self,
+        x_pos: int,
+        frames: Sequence[pygame.Surface],
+        speed: float,
+        frame_time: int,
+    ) -> None:
         super().__init__()
         self.animation = Animation(frames, frame_time)
         self.image = self.animation.get_frame()
         self.rect = self.image.get_rect(midbottom=(x_pos, GROUND_LEVEL))
         self.speed = speed
 
-    def update(self, dt: int):
-        self.rect.x -= self.speed
-        self.animation.update(dt)
+    def update(self, dt: float) -> None:
+        """Advance the animation and move left at ``self.speed``."""
+        self.rect.x -= int(self.speed * dt)
+        self.animation.update(int(dt * 1000))
         self.image = self.animation.get_frame()
         if self.rect.right < 0:
             self.kill()
+
+    def drop(self) -> "Item | None":
+        """Return an item dropped by this enemy, if any."""
+        return None
 
 
 class RunnerEnemy(Enemy):
     """Ground enemy that runs towards the player."""
 
-    def __init__(self, x_pos):
+    def __init__(self, x_pos: int) -> None:
         frames = load_sprite_sheet("assets/runner_sheet.txt", 32, 32)
         super().__init__(x_pos, frames, ENEMY_SPEED, 150)
-        self.rect.midbottom = (x_pos, GROUND_LEVEL)
 
 
 class FlyerEnemy(Enemy):
     """Flying enemy that oscillates vertically."""
 
-    def __init__(self, x_pos):
+    def __init__(self, x_pos: int) -> None:
         frames = load_sprite_sheet("assets/flyer_sheet.txt", 32, 32)
         super().__init__(x_pos, frames, ENEMY_SPEED * 0.8, 150)
         self.rect.midbottom = (x_pos, GROUND_LEVEL - 120)
         self.base_y = self.rect.y
-        self.time = 0
+        self.time = 0.0
 
-    def update(self, dt: int):
+    def update(self, dt: float) -> None:
         super().update(dt)
         self.time += dt
-        self.rect.y = self.base_y + int(math.sin(self.time / 200) * 20)
+        self.rect.y = self.base_y + int(math.sin(self.time * 5) * 20)
 
 
 class BossEnemy(Enemy):
     """Large enemy that stops near the player."""
 
-    def __init__(self, x_pos):
+    def __init__(self, x_pos: int) -> None:
         frames = load_sprite_sheet("assets/boss_sheet.txt", 64, 64)
         super().__init__(x_pos, frames, ENEMY_SPEED * 0.5, 300)
-        self.rect.midbottom = (x_pos, GROUND_LEVEL)
 
-    def update(self, dt: int):
+    def update(self, dt: float) -> None:
         if self.rect.x > WIDTH - 200:
             super().update(dt)
         else:
-            self.animation.update(dt)
+            self.animation.update(int(dt * 1000))
             self.image = self.animation.get_frame()
-=======
-import random
-import pygame
-import pymunk
-import physics
-from settings import ENEMY_SPEED, FPS
-from item import Item
 
-
-class Enemy(pygame.sprite.Sprite):
-    """Simple walking enemy with physics body."""
-
-    def __init__(self, x_pos: float, y_pos: float):
-        super().__init__()
-        self.image = pygame.Surface((40, 40))
-        self.image.fill((255, 0, 0))
-        self.rect = self.image.get_rect(midbottom=(x_pos, y_pos))
-
-        # --- Pymunk body & shape ---
-        mass = 1
-        moment = pymunk.moment_for_box(mass, self.rect.size)
-        self.body = pymunk.Body(mass, moment)
-        self.body.position = self.rect.center
-        self.shape = pymunk.Poly.create_box(self.body, self.rect.size)
-        self.shape.elasticity = 0.0
-
-        physics.space.add(self.body, self.shape)
-
-        # Speed is in pixels/frame; convert to pixels/second via FPS in update()
-        self.speed = ENEMY_SPEED
-
-    def update(self):
-        # Move left at constant horizontal speed; keep current vertical velocity
-        self.body.velocity = (-self.speed * FPS, self.body.velocity.y)
-
-        # Sync sprite after the physics step (or at least each update)
-        self.sync_with_body()
-
-        # Kill when off-screen
-        if self.rect.right < 0:
-            self.kill()
-
-    def sync_with_body(self) -> None:
-        # Keep the pygame rect aligned with the physics body
-        self.rect.center = self.body.position
-
-    def kill(self) -> None:
-        # Clean up physics objects before removing the sprite
-        if self.body in physics.space.bodies or self.shape in physics.space.shapes:
-            try:
-                physics.space.remove(self.body, self.shape)
-            except Exception:
-                # In case they were already removed
-                pass
-        super().kill()
-
-    # hooks for item drops
-    def drop(self):
-        """Return an ``Item`` dropped by this enemy or ``None``.
-
-        The default implementation gives a small random chance to drop a
-        weapon upgrade. Sub-classes can override this to provide custom drop
-        behaviour.
-        """
-        if random.random() < 0.1:
-            return Item(self.rect.midbottom, "weapon", "blaster")
-        return None
-    main

--- a/game.py
+++ b/game.py
@@ -2,11 +2,10 @@ import pygame
 import random
 import physics
 from player import Player
-from enemy import Enemy
+from enemy import RunnerEnemy
 from level import Level
 from item import Item
 from settings import WIDTH, HEIGHT, FPS, SPAWN_DELAY, GROUND_LEVEL
-        main
 
 
 def run():
@@ -36,31 +35,28 @@ def run():
     running = True
     while running:
         dt_ms = clock.tick(FPS)           # milliseconds
-        dt = dt_ms / 1000.0               # seconds (often what physics engines expect)
+        dt = dt_ms / 1000.0               # seconds
 
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
             elif event.type == enemy_event:
-                enemies.add(Enemy(WIDTH + 40, GROUND_LEVEL))
+                enemies.add(RunnerEnemy(WIDTH + 40))
             elif event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE:
-        main
                 player.shoot(bullets)
 
         keys = pygame.key.get_pressed()
 
         # --- Update phase ---
-        level.update(dt)          # if your Level expects seconds, pass dt; if ms, pass dt_ms
+        level.update(dt)
         player.update(keys)
-        bullets.update()
-        enemies.update()
+        bullets.update(dt)
+        enemies.update(dt)
         items.update()
-        physics.update(dt)        # step your physics world; change to dt_ms if your helper expects ms
+        physics.update(dt)
 
         # keep sprites aligned with physics bodies
         player.sync_with_body(level.platform_rects)
-        for enemy in enemies:
-            enemy.sync_with_body()
 
         # --- Collisions & pickups ---
         hits = pygame.sprite.groupcollide(bullets, enemies, True, False)
@@ -75,7 +71,6 @@ def run():
         pickups = pygame.sprite.spritecollide(player, items, True)
         for item in pickups:
             player.inventory.equip(item.item_type, item.name)
-        main
 
         if pygame.sprite.spritecollide(player, enemies, False):
             running = False

--- a/level.py
+++ b/level.py
@@ -7,7 +7,7 @@ import pytmx
 import pymunk
 
 import physics
-from settings import WIDTH, HEIGHT
+from settings import WIDTH, HEIGHT, FPS
 
 
 class Level:
@@ -39,7 +39,7 @@ class Level:
         # Create parallax background layers
         self.parallax_layers = []
         colors = [(20, 20, 40), (40, 40, 80), (60, 60, 120)]
-        speeds = [0.2, 0.5, 1.0]
+        speeds = [0.2 * FPS, 0.5 * FPS, 1.0 * FPS]  # pixels per second
         for color, speed in zip(colors, speeds):
             surf = pygame.Surface((WIDTH, HEIGHT))
             surf.fill(color)
@@ -64,11 +64,11 @@ class Level:
         Parameters
         ----------
         dt: float
-            Milliseconds since last frame.
+            Seconds since last frame.
         """
 
         for layer in self.parallax_layers:
-            layer["x"] = (layer["x"] - layer["speed"]) % WIDTH
+            layer["x"] = (layer["x"] - layer["speed"] * dt) % WIDTH
 
     def draw(self, screen: pygame.Surface) -> None:
         """Draw background and map layers to the screen."""

--- a/physics.py
+++ b/physics.py
@@ -1,14 +1,18 @@
+"""Thin wrapper around a global Pymunk ``Space``."""
+
 import pymunk
-from settings import FPS, GRAVITY
+from settings import GRAVITY
 
 space: pymunk.Space | None = None
 
-def init():
+def init() -> None:
+    """Create the global physics ``Space`` and configure gravity."""
     global space
     space = pymunk.Space()
-    space.gravity = (0, GRAVITY * FPS)
+    space.gravity = (0, GRAVITY)
 
-def update(dt_ms: int):
+def update(dt: float) -> None:
+    """Advance the physics simulation by ``dt`` seconds."""
     if space is None:
         return
-    space.step(dt_ms / 1000.0)
+    space.step(dt)

--- a/settings.py
+++ b/settings.py
@@ -1,10 +1,14 @@
 WIDTH = 800
 HEIGHT = 480
 FPS = 60
-PLAYER_SPEED = 5
-PLAYER_JUMP = 15
-GRAVITY = 0.8
-BULLET_SPEED = 10
-ENEMY_SPEED = 3
+
+# Movement and physics constants are defined in pixels per second (or
+# pixels per second squared for ``GRAVITY``).  They previously used
+# per-frame values which caused gameplay to vary with the frame rate.
+PLAYER_SPEED = 300       # player horizontal speed (px/s)
+PLAYER_JUMP = 900        # initial jump velocity (px/s)
+GRAVITY = 48             # downward acceleration (px/s^2)
+BULLET_SPEED = 600       # projectile speed (px/s)
+ENEMY_SPEED = 180        # base enemy speed (px/s)
 SPAWN_DELAY = 2000  # milliseconds
 GROUND_LEVEL = HEIGHT - 40


### PR DESCRIPTION
## Summary
- replace merge-conflicted enemy module with time-based versions of Runner, Flyer and Boss enemies
- standardize game loop and physics to operate on seconds and pass `dt` to bullets, enemies and level
- document and type-hint major components, making movement constants time-based

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68981fad25c4832680a5a66f27e2317a